### PR TITLE
metaとレイアウト設定

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,10 +2,16 @@
 import '../styles/destyle.css';
 import '../styles/global.css';
 export interface Props {
-	title: string;
+	pageName: string;
+	desc: string;
+	type: string;
 }
 
-const { title } = Astro.props;
+const { pageName, desc, type } = Astro.props;
+const pageTitle = `${pageName} | SkyCoffee`
+
+const url = Astro.url.href;
+const ogImage = `${Astro.url.origin}/og.jpg`
 ---
 
 <!DOCTYPE html>
@@ -15,7 +21,17 @@ const { title } = Astro.props;
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
-		<title>{title}</title>
+		<meta name="description" content={desc} />
+		<meta property="og:title" content={pageTitle} />
+		<meta property="og:description" content={desc} />
+		<meta property="og:type" content={type} />
+		<meta property="og:url" content={url} />
+		<meta property="og:image" content={ogImage} />
+		<meta property="og:site_name" content="Sky Coffee" />
+		<meta name="twitter:title" content={pageTitle} />
+		<meta name="twitter:description" content={desc} />
+		<meta name="twitter:url" content={url} />
+		<title>{pageTitle}</title>
 	</head>
 	<body>
 		<slot />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,83 +1,13 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import Card from '../components/Card.astro';
 import Title from '../components/Title';
 ---
 
-<Layout title="Welcome to Astro.">
-	<main>
-		<h1>Welcome to <span class="text-gradient">Astro</span></h1>
-		<Title>タイトル</Title>
-		<p class="instructions">
-			To get started, open the directory <code>src/pages</code> in your project.<br />
-			<strong>Code Challenge:</strong> Tweak the "Welcome to Astro" message above.
-		</p>
-		<ul role="list" class="link-card-grid">
-			<Card
-				href="https://docs.astro.build/"
-				title="Documentation"
-				body="Learn how Astro works and explore the official API docs."
-			/>
-			<Card
-				href="https://astro.build/integrations/"
-				title="Integrations"
-				body="Supercharge your project with new frameworks and libraries."
-			/>
-			<Card
-				href="https://astro.build/themes/"
-				title="Themes"
-				body="Explore a galaxy of community-built starter themes."
-			/>
-			<Card
-				href="https://astro.build/chat/"
-				title="Community"
-				body="Come say hi to our amazing Discord community. ❤️"
-			/>
-		</ul>
-	</main>
+<Layout
+	pageName="ホーム"
+	desc="Sky Coffeeの説明文が入ります。"
+	type="website"
+>
+	<Title>タイトル</Title>
+	<p>test</p>
 </Layout>
-
-<style>
-	main {
-		margin: auto;
-		padding: 1.5rem;
-		max-width: 60ch;
-	}
-	h1 {
-		font-size: 3rem;
-		font-weight: 800;
-		margin: 0;
-	}
-	.text-gradient {
-		background-image: var(--accent-gradient);
-		-webkit-background-clip: text;
-		-webkit-text-fill-color: transparent;
-		background-size: 400%;
-		background-position: 0%;
-	}
-	.instructions {
-		line-height: 1.6;
-		margin: 1rem 0;
-		border: 1px solid rgba(var(--accent), 25%);
-		background-color: white;
-		padding: 1rem;
-		border-radius: 0.4rem;
-	}
-	.instructions code {
-		font-size: 0.875em;
-		font-weight: bold;
-		background: rgba(var(--accent), 12%);
-		color: rgb(var(--accent));
-		border-radius: 4px;
-		padding: 0.3em 0.45em;
-	}
-	.instructions strong {
-		color: rgb(var(--accent));
-	}
-	.link-card-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(24ch, 1fr));
-		gap: 1rem;
-		padding: 0;
-	}
-</style>


### PR DESCRIPTION
## 概要
metaで必要なタグを追加。
ページ、説明文、サイトのタイプは各ページで設定できるようにした。
初回インストール時からあるレイアウトは削除。