### PR TITLE
Topコンポーネント追加と各所調整

### DIFF
--- a/src/components/Pages/Top/index.stories.tsx
+++ b/src/components/Pages/Top/index.stories.tsx
@@ -1,0 +1,8 @@
+import Top from './index';
+
+export default {
+  title: 'Pages/Top',
+  component: Top,
+};
+
+export const $default: React.FC = () => <Top />;

--- a/src/components/Pages/Top/index.tsx
+++ b/src/components/Pages/Top/index.tsx
@@ -1,0 +1,13 @@
+import MainVisual from '../../Atoms/MainVisual';
+import Nav from '../../Molecules/Nav';
+
+const Top: React.FC = () => {
+  return (
+    <div>
+      <MainVisual />
+      <Nav />
+    </div>
+  )
+}
+
+export default Top;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,10 @@
 ---
 import '../styles/destyle.css';
 import '../styles/global.css';
+
+import Header from '../components/Molecules/Header';
+import Footer from '../components/Molecules/Footer';
+
 export interface Props {
 	pageName: string;
 	desc: string;
@@ -34,6 +38,8 @@ const ogImage = `${Astro.url.origin}/og.jpg`
 		<title>{pageTitle}</title>
 	</head>
 	<body>
+		<Header />
 		<slot />
+		<Footer />
 	</body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import Title from '../components/Title';
-import Header from '../components/Molecules/Header';
-import MainVisual from '../components/Atoms/MainVisual';
-import Nav from '../components/Molecules/Nav';
-import Footer from '../components/Molecules/Footer';
+import Top from '../components/Pages/Top';
 ---
 
 <Layout
@@ -12,10 +8,5 @@ import Footer from '../components/Molecules/Footer';
 	desc="Sky Coffeeの説明文が入ります。"
 	type="website"
 >
-	<Header />
-	<MainVisual />
-	<Nav />
-	<Title>タイトル</Title>
-	<p>test</p>
-	<Footer />
+	<Top />
 </Layout>


### PR DESCRIPTION
## 概要
トップページに入る要素はTopコンポーネントで管理する。
ヘッダーとフッターはページ共通なのでLayoutに記述を移動。

- Topコンポーネント追加
- pages/index.astroを調整
- layout/Layout.astroにHeaderとFooterコンポーネントを追加