### PR TITLE
Buttonコンポーネント追加

### DIFF
--- a/src/components/Atoms/Button/index.stories.tsx
+++ b/src/components/Atoms/Button/index.stories.tsx
@@ -1,0 +1,28 @@
+import { action } from "@storybook/addon-actions";
+import Button from './index';
+
+export default {
+  title: 'Atoms/Button',
+  component: Button,
+};
+
+export const $default: React.FC = () =>
+  <Button
+    label="button"
+    onClick={action('clicked')}
+  />;
+
+export const Link: React.FC = () => 
+  <Button
+    as="a"
+    href="/"
+    label="link"
+  />;
+
+export const ExternalLink: React.FC = () => 
+  <Button
+    as="a"
+    href="https://google.com"
+    label="external link"
+  />;
+

--- a/src/components/Atoms/Button/index.tsx
+++ b/src/components/Atoms/Button/index.tsx
@@ -1,0 +1,46 @@
+import Styles from './styles.module.css';
+
+type Props = {
+  as?: React.ElementType;
+  href?: string;
+  isTarget?: boolean;
+  label: string;
+  onClick?: (event: any) => void
+}
+
+const Button: React.FC<Props> = ({ as: CustomTag = "button", href, isTarget = false, label, onClick }) => {
+  // 外部リンクの条件分岐
+  if(href && href?.indexOf("http") !== -1) {
+    isTarget = true
+  }
+  return (
+    <>
+      {isTarget ? 
+      <CustomTag
+        className={Styles.button}
+        href={href}
+        target="_blank"
+        rel="noopener"
+      >
+        {label}
+        <svg xmlns="http://www.w3.org/2000/svg" width="5" height="9" viewBox="0 0 5 9">
+          <path id="icon_arrow-right" d="M3.757.826a1,1,0,0,1,1.487,0L7.5,3.331A1,1,0,0,1,6.755,5H2.245A1,1,0,0,1,1.5,3.331Z" transform="translate(5) rotate(90)"/>
+        </svg>
+      </CustomTag>
+      :
+        <CustomTag
+          className={Styles.button}
+          href={href}
+          onClick={onClick}
+        >
+          {label}
+          <svg xmlns="http://www.w3.org/2000/svg" width="5" height="9" viewBox="0 0 5 9">
+            <path id="icon_arrow-right" d="M3.757.826a1,1,0,0,1,1.487,0L7.5,3.331A1,1,0,0,1,6.755,5H2.245A1,1,0,0,1,1.5,3.331Z" transform="translate(5) rotate(90)"/>
+          </svg>
+        </CustomTag>
+      }
+    </>
+  )
+}
+
+export default Button;

--- a/src/components/Atoms/Button/styles.module.css
+++ b/src/components/Atoms/Button/styles.module.css
@@ -1,0 +1,30 @@
+.button {
+  display: inline-block;
+  width: 100%;
+  max-width: 220px;
+  padding: 18px 15px;
+  font-size: 1.4rem;
+  font-weight: bold;
+  text-align: center;
+  border: 1px solid var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-white);
+  border-radius: 3px;
+  position: relative;
+  transition: all var(--default-transition);
+}
+
+.button:hover {
+  color: var(--color-white);
+  background: var(--color-primary);
+}
+
+.button svg {
+  width: 5px;
+  height: 9px;
+  fill: currentColor;
+  position: absolute;
+  top: 50%;
+  right: 15px;
+  transform: translateY(-50%);
+}

--- a/src/components/Pages/Top/index.tsx
+++ b/src/components/Pages/Top/index.tsx
@@ -5,6 +5,7 @@ import Nav from '../../Molecules/Nav';
 import SectionBlock from '../../Organaisms/SectionBlock';
 import SectionTitle from '../../Atoms/SectionTitle';
 import BlogList from '../../Organaisms/BlogList';
+import Button from '../../Atoms/Button';
 
 import { blogLists } from '../../../../public/utils/blog'
 
@@ -30,6 +31,11 @@ const Top: React.FC = () => {
           />
           <BlogList
             lists={blogLists}
+          />
+          <Button
+            as="a"
+            href="/blog"
+            label="ブログ一覧"
           />
         </section>
       </div>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout
+	pageName="ブログ"
+	desc="Sky Coffeeの説明文が入ります。"
+	type="website"
+>
+	blog
+</Layout>


### PR DESCRIPTION
## 概要
- Buttonコンポーネント追加
- タグはaタグ、buttonタグどちらにも対応できるようにした
- aタグのhrefが外部の場合、`target="_blank"`と`rel="noopener"`を含める条件分岐を追加

![スクリーンショット 2022-12-01 15 53 46](https://user-images.githubusercontent.com/30612104/204985681-aa031c26-5fdb-437f-9559-d0edc59d2601.png)
